### PR TITLE
Correct url for addon in config.json

### DIFF
--- a/chrony/config.json
+++ b/chrony/config.json
@@ -3,7 +3,7 @@
   "version": "dev",
   "slug": "chrony",
   "description": "chrony NTP Server",
-  "url": "https://github.com/hassio-addons/xxxxx",
+  "url": "https://github.com/hassio-addons/addon-chrony",
   "startup": "application",
   "arch": [
     "aarch64",


### PR DESCRIPTION
# Proposed Changes
Correct url for addon in config.json

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/