### PR TITLE
Changes startup type to system

### DIFF
--- a/chrony/config.json
+++ b/chrony/config.json
@@ -4,7 +4,7 @@
   "slug": "chrony",
   "description": "chrony NTP Server",
   "url": "https://github.com/hassio-addons/addon-chrony",
-  "startup": "application",
+  "startup": "system",
   "arch": [
     "aarch64",
     "amd64",
@@ -19,7 +19,7 @@
   "privileged": [
     "SYS_TIME"
   ],
-  "ports": { 
+  "ports": {
     "123/udp": 123
    },
   "options": {


### PR DESCRIPTION
# Proposed Changes

This will start the add-on way before anything else.
Especially in Home Assistant, the benefits are the system time will be correct before HA starts.

## Related Issues

n/a