### PR TITLE
Removes custom log format override

### DIFF
--- a/chrony/config.json
+++ b/chrony/config.json
@@ -34,8 +34,5 @@
     "ntp_pool": "str?",
     "ntp_server": ["str?"],
     "mode": "match(^(pool|server)$)"
-  },
-  "environment": {
-    "LOG_FORMAT": "{LEVEL}: {MESSAGE}"
   }
 }


### PR DESCRIPTION
# Proposed Changes

This override is still valid, but no longer needed with the introduction of Bashio (which has a more saner and compact log output format by default).

## Related Issues

n/a