### PR TITLE
Allow pools and servers

### DIFF
--- a/chrony/DOCS.md
+++ b/chrony/DOCS.md
@@ -26,11 +26,11 @@ Example add-on configuration:
 
 ```yaml
 set_system_clock: true
-mode: pool
 ntp_pool: pool.ntp.org
 ntp_server:
   - 54.39.13.155
   - briareus.schulte.org
+pool_maxsources: 4
 ```
 
 **Note**: _This is just an example, don't copy and paste it! Create your own!_
@@ -61,23 +61,34 @@ setting the system time.
 
 ### Option: `mode`
 
-The `mode` option configures chrony to use either `pool` or `server` mode.
-These options are:
-
-- `pool`: References a pool of servers such as pool.ntp.org (Recommended).
-- `server`: References a list of specific names or addresses.
-
-Based on the mode the `ntp_pool` or `ntp_server` option will be used.
+Deprecated, ignored.
 
 ### Option: `ntp_pool`
 
-Used by pool mode and configures the pool name to be used, should be a DNS
-record with multiple entries. The application will select which to reference.
+Configures the NTP pool name to be used, should be DNS record with multiple
+entries. The application will select which to reference.
+
+If you don't want to use a pool, set the configuration to empty.
+
+```yaml
+ntp_pool: ""
+```
 
 ### Option: `ntp_server`
 
-Used by server mode, an array of server names or IP Addresses used as the
-time source. The application will select which to reference.
+An array of server names or IP Addresses used as the time sources.
+The application will select which to reference.
+
+If you don't want to use servers, set the configuration to empty.
+
+```yaml
+ntp_server: []
+```
+
+### Option: `pool_maxsources`
+
+The number of servers to select from the pool DNS record. Must be between
+1 and 16. The default is 4.
 
 ## Changelog & Releases
 

--- a/chrony/config.yaml
+++ b/chrony/config.yaml
@@ -18,15 +18,14 @@ ports_description:
   123/udp: NTP; Network Time Protocol
 options:
   set_system_clock: true
-  mode: pool
   ntp_pool: pool.ntp.org
-  ntp_server:
-    - 54.39.13.155
-    - briareus.schulte.org
+  ntp_server: []
+  pool_maxsources: 4
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   set_system_clock: bool
   ntp_pool: str?
   ntp_server:
     - str?
-  mode: list(pool|server)
+  pool_maxsources: int(1,16)
+  mode: list(pool|server)?

--- a/chrony/rootfs/etc/s6-overlay/s6-rc.d/init-chrony/run
+++ b/chrony/rootfs/etc/s6-overlay/s6-rc.d/init-chrony/run
@@ -5,48 +5,37 @@
 # Configures chrony
 # ==============================================================================
 readonly CHRONY_CONF='/etc/chrony/chrony.conf'
-declare mode
+declare ntp_pool
+declare pool_maxsources
 declare -a serverlist
 
-# Check running mode
-if bashio::config.equals 'mode' 'pool' \
+# Check if configuration is valid.
+if bashio::config.is_empty 'ntp_server' \
     && bashio::config.is_empty 'ntp_pool';
 then
     bashio::log.fatal
     bashio::log.fatal 'Configuration of this add-on is incomplete.'
     bashio::log.fatal
-    bashio::log.fatal 'pool mode is configured but the ntp_pool'
-    bashio::log.fatal 'is empty'
-    bashio::log.fatal
-    bashio::log.fatal 'If using pool mode please set the'
-    bashio::log.fatal '"ntp_pool" option in the add-on'
-    bashio::log.fatal 'configuration.'
+    bashio::log.fatal 'Both "ntp_pool" and "ntp_server" configurations'
+    bashio::log.fatal 'are empty in the add-on configuration.'
     bashio::log.fatal
     bashio::exit.nok
 fi
 
-if bashio::config.equals 'mode' 'server' \
-    && bashio::config.is_empty 'ntp_server';
+# Write the configuration file.
+
+ntp_pool=$(bashio::config "ntp_pool")
+if [[ -n "${ntp_pool}" ]]
 then
-    bashio::log.fatal
-    bashio::log.fatal 'Configuration of this add-on is incomplete.'
-    bashio::log.fatal
-    bashio::log.fatal 'server mode is configured but the ntp_server'
-    bashio::log.fatal 'is empty'
-    bashio::log.fatal
-    bashio::log.fatal 'If using server mode please set the'
-    bashio::log.fatal '"ntp_server" option in the add-on'
-    bashio::log.fatal 'configuration.'
-    bashio::log.fatal
-    bashio::exit.nok
+    pool_maxsources=$(bashio::config "pool_maxsources")
+    bashio::log.debug "Adding pool ${ntp_pool}"
+    echo "pool ${ntp_pool} iburst maxsources ${pool_maxsources}" >> ${CHRONY_CONF}
+    serverlist+=("${ntp_pool}")
 fi
 
-# Write configuration file
-mode=$(bashio::config 'mode')
-bashio::log.debug "Running in NTP mode: ${mode}"
-for server in $(bashio::config "ntp_${mode}"); do
+for server in $(bashio::config "ntp_server"); do
     bashio::log.debug "Adding server ${server}"
-    echo "${mode} ${server} iburst" >> ${CHRONY_CONF}
+    echo "server ${server} iburst" >> ${CHRONY_CONF}
     serverlist+=("${server}")
 done
 


### PR DESCRIPTION
# Proposed Changes

Chrony allows both pools and servers to be used simultaneously. For example using a local time server in addition to a public NTP service.
* Support both `ntp_pool` and `ntp_server` to be used at the same time.
* Add `maxsources` option to pool configuration.

## Related Issues

None

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to limit servers selected from NTP pool DNS records (1–16, default 4).

* **Documentation**
  * Clarified pool vs. server behavior, added explicit empty-value examples for optional settings.
  * Marked legacy mode option as deprecated/ignored.

* **Configuration Changes**
  * Default server list is now empty; either a pool or explicit servers must be configured.
  * Mode is now optional; validation requires at least one of pool or servers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->